### PR TITLE
Bug fix

### DIFF
--- a/simplemysql/simplemysql.py
+++ b/simplemysql/simplemysql.py
@@ -237,7 +237,7 @@ class SimpleMysql:
 
 	def query(self, sql, params = []):
 		"""Run a raw query"""
-		params = params if params else []
+		params = params if params and len(params) > 0 else None
 
 		# check if connection is alive. if not, reconnect
 		try:


### PR DESCRIPTION
According to python mysqlclient package source code https://github.com/PyMySQL/mysqlclient/blob/main/MySQLdb/cursors.py#L171  the default value for args should be None. If we use the empty list, it can raise errors in some cases.